### PR TITLE
Feature/go back btn

### DIFF
--- a/cypress/integration/foodtruck.spec.js
+++ b/cypress/integration/foodtruck.spec.js
@@ -159,6 +159,10 @@ describe('truck details', () => {
             cy.request(href).its('status').should('eq', 200)
         })
         cy.get('[data-cy=truck-description]').contains("Arturo's unique recipes are a fusion of Spanish and traditional Mexican. Clean, simple and healthy Mexican food. Only 3 people prepare the food we serve to our clients, from the local produce and local butcher, there is not third parties when it comes to prepare our dishes. We closely follow Health Authority guidances and protocols to operate our business. We have been serving take out food at open spaces since 2010, and we will continue doing it, safety is our priority.");
+        const payments = ['cash', 'credit card', 'debit card', 'apple pay']
+        cy.get('[data-cy=payment-methods]').children().each(($payment, i) => {
+           cy.wrap($payment).should('contain', payments[i])
+        })
     });
 
     it('should display a default logo if there is no logo provided', () => {
@@ -166,5 +170,16 @@ describe('truck details', () => {
         cy.get('[data-cy=truck-list-button]').click();
         cy.get('[data-cy=truck-card]').eq(1).click();
         cy.get('[data-cy=truck-details-logo]').should('have.attr', 'src').should('include', 'food-truck' );
+    });
+
+    it('should take a user back to their previouly viewed page', () => {
+        Cypress.on('uncaught:exception', (err, runnable) => {
+            return false
+          });
+        cy.get('[data-cy=truck-list-button]');
+        cy.get('[data-cy=truck-list-button]').click();
+        cy.get('[data-cy=truck-card]').first().click();
+        cy.get('[data-cy=truck-details-back-btn]').click();
+        cy.url().should('eq', 'http://localhost:3000/trucklist');
     })
 });

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -84,7 +84,7 @@ class App extends Component {
               showTruckDetails={this.showTruckDetails}
             />
           </Route> 
-          <Route  exact path="/trucks/:name" render={({ match }) => {
+          <Route  exact path="/trucks/:name" render={({ match, history }) => {
             const clickedTruck = this.state.trucks.find(truck => {
               const truckName = match.params.name.split('_').join(' ')
               return truckName === truck.attributes.name
@@ -92,6 +92,7 @@ class App extends Component {
            
              return <TruckDetails 
                       truckDetails={clickedTruck}
+                      history={history}
                     />
           }}/>
          

--- a/src/components/TruckDetails/TruckDetails.js
+++ b/src/components/TruckDetails/TruckDetails.js
@@ -1,46 +1,50 @@
 import React from 'react';
 import SocialMediaLinks from '../SocialMediaLinks/SocialMediaLinks';
 import truckIcon from '../../assets/food-truck.svg';
+import { TiArrowBack } from 'react-icons/ti';
 
 const TruckDetails = ({ truckDetails }) => {
   console.log(truckDetails)
   return (
-    <section className="truck-details-container" data-cy="truck-info">
-      <div className="truck-details-links">
-        <h1 className="truck-details-name" data-cy="truck-name">{truckDetails.attributes.name}</h1>
-        <a 
-          href={truckDetails.attributes.website} className="truck-website"
-          data-cy="truck-details-website"
-          >
-            {truckDetails.attributes.website}
-        </a>
-      </div>
-      <div className="speech-bubble">
-        <div className="circular-sb">
-        Yum!
-        <div className="circle1"></div>
-        <div className="circle2"></div>
-      </div>
-      </div>
-      {!truckDetails.attributes.logo && 
-        <img 
-      src={truckIcon} 
-      alt={`${truckDetails.attributes.name} logo`} 
-      className="truck-details-logo-default"
-      data-cy="truck-details-logo"
-        />
-      }
-      {truckDetails.attributes.logo && <img 
-        src={truckDetails.attributes.logo} 
+    <section>
+      <TiArrowBack className="truck-details-back-btn"/>
+      <article className="truck-details-container" data-cy="truck-info">
+        <div className="truck-details-links">
+          <h1 className="truck-details-name" data-cy="truck-name">{truckDetails.attributes.name}</h1>
+          <a 
+            href={truckDetails.attributes.website} className="truck-website"
+            data-cy="truck-details-website"
+            >
+              {truckDetails.attributes.website}
+          </a>
+        </div>
+        <div className="speech-bubble">
+          <div className="circular-sb">
+          Yum!
+          <div className="circle1"></div>
+          <div className="circle2"></div>
+        </div>
+        </div>
+        {!truckDetails.attributes.logo && 
+          <img 
+        src={truckIcon} 
         alt={`${truckDetails.attributes.name} logo`} 
-        className="truck-details-logo"
+        className="truck-details-logo-default"
         data-cy="truck-details-logo"
-      />}
-      <SocialMediaLinks
-        links={truckDetails.attributes.socials}
-      />
-      <p className="truck-details-intro" data-cy="truck-intro">About Us:</p>
-      <p className="truck-details-description" data-cy="truck-description">{truckDetails.attributes.description}</p>
+          />
+        }
+        {truckDetails.attributes.logo && <img 
+          src={truckDetails.attributes.logo} 
+          alt={`${truckDetails.attributes.name} logo`} 
+          className="truck-details-logo"
+          data-cy="truck-details-logo"
+        />}
+        <SocialMediaLinks
+          links={truckDetails.attributes.socials}
+        />
+        <p className="truck-details-intro" data-cy="truck-intro">About Us:</p>
+        <p className="truck-details-description" data-cy="truck-description">{truckDetails.attributes.description}</p>
+      </article>
     </section>
   )
 }

--- a/src/components/TruckDetails/TruckDetails.js
+++ b/src/components/TruckDetails/TruckDetails.js
@@ -13,6 +13,7 @@ const TruckDetails = ({ truckDetails, history }) => {
         className="truck-details-back-btn" 
         onClick={() => history.goBack()} 
         alt="go-back"
+        data-cy="truck-details-back-btn"
       >
         <TiArrowBack className="truck-details-back-icon"/>
       </button>
@@ -53,7 +54,7 @@ const TruckDetails = ({ truckDetails, history }) => {
         <p className="truck-details-intro" data-cy="truck-intro">About Us:</p>
         <p className="truck-details-info" data-cy="truck-description">{truckDetails.attributes.description}</p>
         <p className="truck-details-intro">Payment Types:</p>
-        <div className="truck-details-payments-container">
+        <div className="truck-details-payments-container" data-cy="payment-methods">
           {paymentTypes}
         </div>
       </article>

--- a/src/components/TruckDetails/TruckDetails.js
+++ b/src/components/TruckDetails/TruckDetails.js
@@ -3,12 +3,20 @@ import SocialMediaLinks from '../SocialMediaLinks/SocialMediaLinks';
 import truckIcon from '../../assets/food-truck.svg';
 import { TiArrowBack } from 'react-icons/ti';
 
-const TruckDetails = ({ truckDetails }) => {
-  console.log(truckDetails)
+const TruckDetails = ({ truckDetails, history }) => {
+  const paymentTypes = truckDetails.attributes.payment_methods.map(method => {
+    return <p className="truck-details-info">{method.split('_').join(' ')} <span className="divider">|</span></p>
+  })
   return (
-    <section>
-      <TiArrowBack className="truck-details-back-btn"/>
-      <article className="truck-details-container" data-cy="truck-info">
+    <section className="truck-details-container">
+      <button
+        className="truck-details-back-btn" 
+        onClick={() => history.goBack()} 
+        alt="go-back"
+      >
+        <TiArrowBack className="truck-details-back-icon"/>
+      </button>
+      <article className="truck-details-card" data-cy="truck-info">
         <div className="truck-details-links">
           <h1 className="truck-details-name" data-cy="truck-name">{truckDetails.attributes.name}</h1>
           <a 
@@ -43,7 +51,11 @@ const TruckDetails = ({ truckDetails }) => {
           links={truckDetails.attributes.socials}
         />
         <p className="truck-details-intro" data-cy="truck-intro">About Us:</p>
-        <p className="truck-details-description" data-cy="truck-description">{truckDetails.attributes.description}</p>
+        <p className="truck-details-info" data-cy="truck-description">{truckDetails.attributes.description}</p>
+        <p className="truck-details-intro">Payment Types:</p>
+        <div className="truck-details-payments-container">
+          {paymentTypes}
+        </div>
       </article>
     </section>
   )

--- a/src/components/TruckDetails/TruckDetails.scss
+++ b/src/components/TruckDetails/TruckDetails.scss
@@ -9,6 +9,13 @@
   position: relative; 
 }
 
+.truck-details-back-btn {
+  width: 35px;
+  height: 35px; 
+  margin: 5px; 
+  color: $dark-blue-green;  
+}
+
 .truck-details-logo {
   width: 80%;
   max-width: 400px; 

--- a/src/components/TruckDetails/TruckDetails.scss
+++ b/src/components/TruckDetails/TruckDetails.scss
@@ -1,4 +1,10 @@
 .truck-details-container {
+  display: flex;
+  flex-direction: column; 
+  align-items: center;  
+}
+
+.truck-details-card {
   width: 95%; 
   font-size: 1.4em;
   background-color: #FFF; 
@@ -10,6 +16,13 @@
 }
 
 .truck-details-back-btn {
+  align-self: flex-start;  
+  border: none; 
+  background: none; 
+}
+
+.truck-details-back-icon {
+  align-self: flex-start; 
   width: 35px;
   height: 35px; 
   margin: 5px; 
@@ -49,14 +62,24 @@
   padding: 5px 0px 0px 5px;
   margin: 0px; 
   color: $dark-blue-green;
-  font-size: 1.4em; 
+  font-size: 1.2em; 
   font-weight: 600;  
 }
 
-.truck-details-description {
+.truck-details-info {
   font-size: 1.2em; 
   margin: 0px; 
-  padding: 5px;    
+  padding: 10px;    
+}
+
+.truck-details-payments-container {
+  display: flex; 
+  flex-wrap: wrap; 
+}
+
+.divider {
+  color: $light-blue-green;
+  font-weight: 600; 
 }
 
 .speech-bubble {


### PR DESCRIPTION
## What does this PR do?

- This adds a "go back" button on the truck details card so the user can return to their previously viewed screen
- Truck details card was updated to show payment methods
- Cypress testing was updated to reflect new functionality

## How should it be tested?

- Pull the branch down, visit truck details from map and from truck list, when you click the back button you should be taken back to the previously viewed screen
- run the cypress test suite, all tests should be passing

## What do the future iterations hold?

- N/A

## Linked Issues
- #54 
