### PR TITLE
Add local storage condition to state initialization

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -10,7 +10,9 @@ import TruckList from './TruckList/TruckList';
 class App extends Component {
   constructor() {
     super() 
-    this.state = {
+    this.state = JSON.parse(localStorage.getItem('state')) 
+    ? JSON.parse(localStorage.getItem('state'))
+    : {
       userLocation: {}, 
       radius: 5,
       trucks:[],
@@ -27,7 +29,9 @@ class App extends Component {
       .then(trucks => {
         // console.log(trucks)
         const sortedTrucks = this.sortByDistance(trucks.data)
-        this.setState({ userLocation: {lat: 42.346251, lng: -71.09817}, trucks: sortedTrucks})
+        this.setState({ userLocation: {lat: 42.346251, lng: -71.09817}, trucks: sortedTrucks}, () => {
+          localStorage.setItem('state', JSON.stringify(this.state))
+        })
       })
     })
     .catch(error => this.setState({ error: error.message }))


### PR DESCRIPTION
## What does this PR do?

- Local storage is utilized to persist state on page refresh
- A condition was added in the App state to check local storage or initialize state with a default value
- when state is initialized with values in loginUser, the state is set and a callback function is used to update the local storage with the new values

## How should it be tested?
- Open up dev tools and navigate to the local storage option under application
- Make sure local storage is clear, sign into the app using the user "test" and navigate to each view
- refresh each view to see the data persist
- Navigate back to the login page, and sign in with a different user and navigate to each view
- refresh each view to see the data persist
- Make sure the data reflects each user

## What do the future iterations hold?

- Do we want to save it to session storage instead? the difference is when the window is closed, local storage is cleared, I think the syntax is all the same, and just need to direct to session storage instead of local storage

## Linked Issues
- #55 