### PR TITLE
Feature/set radius

### DIFF
--- a/cypress/integration/foodtruck.spec.js
+++ b/cypress/integration/foodtruck.spec.js
@@ -106,6 +106,15 @@ describe('Map view', () => {
         cy.wait('@truck-markers');
         cy.get('[data-cy=change-location-button]').click().url().should('eq', 'http://localhost:3000/newlocation')
     });
+
+    it('should allow the user to change the radius', () => {
+        cy.get('[data-cy=set-radius]').select('10').should('have.value', '10');
+    });
+
+    it('should allow the user to set the radius back to default', () => {
+        cy.get('[data-cy=set-radius]').select('10').should('have.value', '10');
+        cy.get('[data-cy=set-radius]').select('All Trucks').should('have.value', '40');
+    });
 });
 
 describe('New location view', () => {

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -34,7 +34,7 @@ const MapView = ({ trucks, center }) => {
             value={radius}
             onChange={e => setRadius(Number(e.target.value))}
           >
-              <option value="select-option">--Please choose an option--</option>
+              <option value="40">All Trucks</option>
               <option value="30">30 miles</option>
               <option value="20">20 miles</option>
               <option value="10">10 miles</option>

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -20,20 +20,24 @@ const MapView = ({ trucks, center }) => {
   return (
       <main>
         <div className="map-buttons-container">
-          <Link to="/trucklist">
-            <button className="button" data-cy='truck-list-button'>Truck List</button>
-          </Link>
-          <Link to="/newlocation">
-            <button className="button" data-cy='change-location-button'>Change Location</button>
-          </Link>
-          <label htmlFor="set-radius">Set Radius:</label>
-          <select
-            className="map-select-radius" 
-            name="radius" 
-            id="set-radius"
-            value={radius}
-            onChange={e => setRadius(Number(e.target.value))}
-          >
+          <div>
+            <Link to="/trucklist">
+              <button className="button" data-cy='truck-list-button'>Truck List</button>
+            </Link>
+            <Link to="/newlocation">
+              <button className="button" data-cy='change-location-button'>Change Location</button>
+            </Link>
+          </div>
+          <div>
+            <label className="map-radius-label" htmlFor="set-radius">Set Radius:</label>
+            <select
+              className="map-select-radius" 
+              name="radius" 
+              id="set-radius"
+              value={radius}
+              onChange={e => setRadius(Number(e.target.value))}
+            >
+            
               <option value="40">All Trucks</option>
               <option value="30">30 miles</option>
               <option value="20">20 miles</option>
@@ -41,7 +45,8 @@ const MapView = ({ trucks, center }) => {
               <option value="5">5 miles</option>
               <option value="3">3 miles</option>
               <option value="1">1 mile</option>
-          </select>
+            </select>
+          </div>
         </div>
         <section className="map-container">
           <LoadScript

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -29,13 +29,17 @@ const MapView = ({ trucks, center }) => {
             </Link>
           </div>
           <div>
-            <label className="map-radius-label" htmlFor="set-radius">Set Radius:</label>
+            <label 
+              className="map-radius-label" 
+              htmlFor="set-radius">Set Radius:
+            </label>
             <select
               className="map-select-radius" 
               name="radius" 
               id="set-radius"
               value={radius}
               onChange={e => setRadius(Number(e.target.value))}
+              data-cy="set-radius"
             >
             
               <option value="40">All Trucks</option>

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -13,6 +13,7 @@ function createKey(truck) {
 const MapView = ({ trucks, center }) => {
   const [selectedCenter, setSelectedCenter] = useState(null);
   const [clickedTruck, setClickedTruck] = useState('');
+  const [radius, setRadius] = useState('');
 
   if(!Object.keys(center).length) {
     return (
@@ -28,6 +29,22 @@ const MapView = ({ trucks, center }) => {
           <Link to="/newlocation">
             <button className="button" data-cy='change-location-button'>Change Location</button>
           </Link>
+          <label for="set-radius">Set Radius:</label>
+          <select
+            className="map-select-radius" 
+            name="radius" 
+            id="set-radius"
+            value={radius}
+            onChange={e => setRadius(e.target.value)}
+          >
+              <option value="select-option">--Please choose an option--</option>
+              <option value="30 miles">30 miles</option>
+              <option value="20 miles">20 miles</option>
+              <option value="10 miles">10 miles</option>
+              <option value="5 miles">5 miles</option>
+              <option value="3 miles">3 miles</option>
+              <option value="1 mile">1 mile</option>
+          </select>
         </div>
         <section className="map-container">
           <LoadScript

--- a/src/components/MapView/MapView.js
+++ b/src/components/MapView/MapView.js
@@ -1,19 +1,16 @@
 import  React from 'react';
 import { useState } from 'react';
-import { createTruckLocation } from '../../utility.js';
+import { createTruckLocation, createKey, createTrucksByRadius } from '../../utility.js';
 import { GoogleMap, LoadScript, MarkerClusterer, Marker, InfoWindow } from '@react-google-maps/api';
 import { Link } from 'react-router-dom';
 import truckIcon from '../../assets/food-truck.svg';
 const apiKey = process.env.REACT_APP_API_KEY;
 
-function createKey(truck) {
-  return truck.attributes.lat + truck.attributes.long
-}
-
 const MapView = ({ trucks, center }) => {
   const [selectedCenter, setSelectedCenter] = useState(null);
   const [clickedTruck, setClickedTruck] = useState('');
-  const [radius, setRadius] = useState('');
+  const [radius, setRadius] = useState(40);
+  const trucksByRadius = createTrucksByRadius(trucks, radius);
 
   if(!Object.keys(center).length) {
     return (
@@ -29,21 +26,21 @@ const MapView = ({ trucks, center }) => {
           <Link to="/newlocation">
             <button className="button" data-cy='change-location-button'>Change Location</button>
           </Link>
-          <label for="set-radius">Set Radius:</label>
+          <label htmlFor="set-radius">Set Radius:</label>
           <select
             className="map-select-radius" 
             name="radius" 
             id="set-radius"
             value={radius}
-            onChange={e => setRadius(e.target.value)}
+            onChange={e => setRadius(Number(e.target.value))}
           >
               <option value="select-option">--Please choose an option--</option>
-              <option value="30 miles">30 miles</option>
-              <option value="20 miles">20 miles</option>
-              <option value="10 miles">10 miles</option>
-              <option value="5 miles">5 miles</option>
-              <option value="3 miles">3 miles</option>
-              <option value="1 mile">1 mile</option>
+              <option value="30">30 miles</option>
+              <option value="20">20 miles</option>
+              <option value="10">10 miles</option>
+              <option value="5">5 miles</option>
+              <option value="3">3 miles</option>
+              <option value="1">1 mile</option>
           </select>
         </div>
         <section className="map-container">
@@ -76,7 +73,7 @@ const MapView = ({ trucks, center }) => {
             
                 <MarkerClusterer>
                   {(clusterer) =>
-                  trucks.map((truck) => (
+                  trucksByRadius.map((truck) => (
                     <Marker 
                       key={createKey(truck)}
                       title={truck.attributes.name}

--- a/src/components/MapView/MapView.scss
+++ b/src/components/MapView/MapView.scss
@@ -4,12 +4,36 @@
 }
 
 .map-buttons-container {
-  margin: 10px; 
+  margin: 10px;
+  display: flex;
+  flex-direction: column; 
+  align-items: center; 
 }
 
 .map {
   height: 400px;
   width: 100%; 
+}
+
+.map-radius-label {
+  font-size: 1.4em;
+  font-weight: 600;
+  margin-right: 10px;   
+}
+
+.map-select-radius {
+  font-size: 1.4em; 
+  width: 100px; 
+  border: thin solid $light-blue-green;
+  height: 30px; 
+  color: $dark-blue-green;  
+}
+
+@media screen and(min-width: 500px) {
+  .map-buttons-container {
+    flex-direction: row;
+    justify-content: space-around;  
+  }
 }
 
 @media screen and(min-width: 900px ) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,3 +1,14 @@
 export const createTruckLocation = (truck)  => {
   return {lat: Number(truck.attributes.lat), lng: Number(truck.attributes.long) }
 }
+
+export const createKey = (truck) => {
+  return truck.attributes.lat + truck.attributes.long
+}
+
+export const createTrucksByRadius = (trucks, radius) => {
+  const trucksByRadius = trucks.filter(truck => {
+    return Number(truck.attributes.distance) <= radius;
+  });
+  return trucksByRadius
+}


### PR DESCRIPTION
## What does this PR do?

- A set radius feature was added
- There is now a dropdown menu that provides mileages for the user to filter the trucks on the map
- The default radius is set to 40miles on load, and the user can filter down from there and back up to the default

## How should it be tested?

- Sign in with user "test" and set the radius to 3 miles => you should see a truck disappear
- Then set the radius to 10 miles => you should see the truck reappear

## What do the future iterations hold?
- potentially filtering the truck cards by radius too, but for now we decided that since the cards are ordered by distance that it isn't necessary for UX.

## Linked Issues

- #44 
- #19 
